### PR TITLE
Make shas in commit cards redirect to respective github page

### DIFF
--- a/src/app/main-content/dashboard/git-history/git-history.component.html
+++ b/src/app/main-content/dashboard/git-history/git-history.component.html
@@ -96,7 +96,11 @@
                 <span class="author">{{commit.benchmarkedCommit.author}} </span>
                 <span class="message-preview">{{commit.benchmarkedCommit.message | abbreviate: 50}}</span>
             </mat-expansion-panel-header>
-            <section class="hash">{{commit.benchmarkedCommit.sha}}</section>
+            <section class="hash">
+                <a class="commitLink"
+                   href="https://github.com/ginkgo-project/ginkgo/commit/{{commit.benchmarkedCommit.sha}}"
+                   target="_blank">{{commit.benchmarkedCommit.sha}}</a>
+            </section>
             <section class="message">{{commit.benchmarkedCommit.message}}</section>
             <section class="devices">
                 <ul>

--- a/src/app/main-content/dashboard/git-history/git-history.component.scss
+++ b/src/app/main-content/dashboard/git-history/git-history.component.scss
@@ -122,3 +122,8 @@ input[type=number] {
   font-style: oblique;
   color: $nord4;
 }
+
+.commitLink {
+  color: $nord9;
+  text-decoration: underline;
+}


### PR DESCRIPTION
The commit shas in expanded cards on the dashboard now are links that redirect to the commit's respective GitHub page.
The shas are underlined as well now to make it more apparent that they are links. See #140.

For example:
<img width="605" alt="image" src="https://user-images.githubusercontent.com/45409137/164936573-4d614575-211e-47ba-9047-76140011ec94.png">
