### PR TITLE
Make plot pages display commit and device info

### DIFF
--- a/src/app/main-content/bar-plot/bar-plot.component.html
+++ b/src/app/main-content/bar-plot/bar-plot.component.html
@@ -1,5 +1,7 @@
 <mat-card>
   <mat-card-title>Bar Plot</mat-card-title>
+  <mat-card-subtitle>{{this.commits}}</mat-card-subtitle>
+  <mat-card-subtitle>{{this.devices}}</mat-card-subtitle>
 
   <div class="plot">
     <canvas [chartType]="chartType"

--- a/src/app/main-content/bar-plot/bar-plot.component.ts
+++ b/src/app/main-content/bar-plot/bar-plot.component.ts
@@ -6,6 +6,7 @@ import {BaseChartDirective, Label} from "ng2-charts";
 import {PlotConfiguration} from "../../../logic/plothandler/interfaces/plot-configuration";
 import {PlotUtils} from "../../../lib/plot-component-util/plot-utils";
 import {ParkviewLibDataService} from "../../../logic/datahandler/kotlin/parkview-lib-data.service";
+import {PlotService} from "../../../logic/plothandler/plot.service";
 
 @Component({
   selector: 'app-bar-plot',
@@ -17,6 +18,8 @@ export class BarPlotComponent implements OnInit {
   @ViewChild(BaseChartDirective)
   private chart: { refresh: () => void } = {refresh: () => console.log('chart not initialized yet')};
 
+  public devices: string = "";
+  public commits: string = "";
   public readonly chartType: ChartType = 'bar';
   public chartTitle: string = '';
   public chartData: ChartDataSets[] = Array();
@@ -69,7 +72,7 @@ export class BarPlotComponent implements OnInit {
   };
 
 
-  constructor(private readonly route: ActivatedRoute, private readonly dataHandler: ParkviewLibDataService) {
+  constructor(private readonly route: ActivatedRoute, private readonly dataHandler: ParkviewLibDataService, private readonly plotService: PlotService) {
   }
 
   ngOnInit() {
@@ -82,6 +85,8 @@ export class BarPlotComponent implements OnInit {
       if (config === undefined) {
         return;
       }
+      this.commits = "Commits: " + this.plotService.formatCommits(config.commits);
+      this.devices = "Devices: " + this.plotService.formatDevices(config.devices);
       this.chartTitle = config.labelForTitle;
       this.xLabel = config.labelForXAxis;
       this.yLabel = config.labelForYAxis;

--- a/src/app/main-content/line-plot/line-plot.component.html
+++ b/src/app/main-content/line-plot/line-plot.component.html
@@ -1,6 +1,8 @@
 <mat-card>
 
   <mat-card-title>Line Plot - {{chartTitle}}</mat-card-title>
+  <mat-card-subtitle>{{this.commits}}</mat-card-subtitle>
+  <mat-card-subtitle>{{this.devices}}</mat-card-subtitle>
 
   <div class="plot">
     <canvas [chartType]="chartType"

--- a/src/app/main-content/line-plot/line-plot.component.ts
+++ b/src/app/main-content/line-plot/line-plot.component.ts
@@ -6,6 +6,7 @@ import {PlotConfiguration} from "../../../logic/plothandler/interfaces/plot-conf
 import {BaseChartDirective} from "ng2-charts";
 import {PlotUtils} from "../../../lib/plot-component-util/plot-utils";
 import {ParkviewLibDataService} from "../../../logic/datahandler/kotlin/parkview-lib-data.service";
+import {PlotService} from "../../../logic/plothandler/plot.service";
 
 @Component({
   selector: 'app-line-plot',
@@ -17,6 +18,8 @@ export class LinePlotComponent implements OnInit {
   @ViewChild(BaseChartDirective)
   private chart: { refresh: () => void } = {refresh: () => console.log('chart not initialized yet')};
 
+  public devices: string = "";
+  public commits: string = "";
   public readonly chartType: ChartType = 'line';
   public chartData: ChartDataSets[] = Array();
   public chartTitle: string = '';
@@ -78,7 +81,7 @@ export class LinePlotComponent implements OnInit {
   };
 
 
-  constructor(private readonly route: ActivatedRoute, private readonly dataHandler: ParkviewLibDataService) {
+  constructor(private readonly route: ActivatedRoute, private readonly dataHandler: ParkviewLibDataService, private readonly plotService: PlotService) {
   }
 
   ngOnInit() {
@@ -91,6 +94,8 @@ export class LinePlotComponent implements OnInit {
       if (config === undefined) {
         return;
       }
+      this.commits = "Commits: " + this.plotService.formatCommits(config.commits);
+      this.devices = "Devices: " + this.plotService.formatDevices(config.devices);
       if (config.plotType === "Performance Plot") {
         this.yType = "linear";
       }

--- a/src/app/main-content/mixed-plot/mixed-plot.component.html
+++ b/src/app/main-content/mixed-plot/mixed-plot.component.html
@@ -1,6 +1,8 @@
 <mat-card>
     <mat-card-title>Smoothed Plot - {{chartTitle}}</mat-card-title>
-  
+    <mat-card-subtitle>{{this.commits}}</mat-card-subtitle>
+    <mat-card-subtitle>{{this.devices}}</mat-card-subtitle>
+
     <div class="plot">
       <canvas [chartType]="chartType"
               [datasets]="chartData"

--- a/src/app/main-content/mixed-plot/mixed-plot.component.ts
+++ b/src/app/main-content/mixed-plot/mixed-plot.component.ts
@@ -6,6 +6,7 @@ import {BaseChartDirective} from "ng2-charts";
 import {PlotConfiguration} from "../../../logic/plothandler/interfaces/plot-configuration";
 import {PlotUtils} from "../../../lib/plot-component-util/plot-utils";
 import {ParkviewLibDataService} from "../../../logic/datahandler/kotlin/parkview-lib-data.service";
+import {PlotService} from "../../../logic/plothandler/plot.service";
 
 @Component({
   selector: 'app-scatter-plot',
@@ -17,6 +18,8 @@ export class ScatterPlotComponent implements OnInit {
   @ViewChild(BaseChartDirective)
   private chart: { refresh: () => void } = {refresh: () => console.log('chart not initialized yet')};
 
+  public devices: string = "";
+  public commits: string = "";
   public readonly chartType: ChartType = 'scatter';
   public chartTitle = '';
   public chartData: ChartDataSets[] = Array();
@@ -84,7 +87,7 @@ export class ScatterPlotComponent implements OnInit {
   };
 
 
-  constructor(private readonly route: ActivatedRoute, private readonly dataHandler: ParkviewLibDataService) {
+  constructor(private readonly route: ActivatedRoute, private readonly dataHandler: ParkviewLibDataService, private readonly plotService: PlotService) {
   }
 
   ngOnInit() {
@@ -97,6 +100,8 @@ export class ScatterPlotComponent implements OnInit {
       if (config === undefined) {
         return;
       }
+      this.commits = "Commits: " + this.plotService.formatCommits(config.commits);
+      this.devices = "Devices: " + this.plotService.formatDevices(config.devices);
       this.chartTitle = config.labelForTitle;
       this.xLabel = config.labelForXAxis;
       this.yLabel = config.labelForYAxis;

--- a/src/app/main-content/scatter-plot/scatter-plot.component.html
+++ b/src/app/main-content/scatter-plot/scatter-plot.component.html
@@ -1,5 +1,7 @@
 <mat-card>
   <mat-card-title>Scatter Plot - {{chartTitle}}</mat-card-title>
+  <mat-card-subtitle>{{this.commits}}</mat-card-subtitle>
+  <mat-card-subtitle>{{this.devices}}</mat-card-subtitle>
 
   <div class="plot">
     <canvas [chartType]="chartType"

--- a/src/app/main-content/scatter-plot/scatter-plot.component.ts
+++ b/src/app/main-content/scatter-plot/scatter-plot.component.ts
@@ -6,6 +6,7 @@ import {BaseChartDirective} from "ng2-charts";
 import {PlotConfiguration} from "../../../logic/plothandler/interfaces/plot-configuration";
 import {PlotUtils} from "../../../lib/plot-component-util/plot-utils";
 import {ParkviewLibDataService} from "../../../logic/datahandler/kotlin/parkview-lib-data.service";
+import {PlotService} from "../../../logic/plothandler/plot.service";
 
 @Component({
   selector: 'app-scatter-plot',
@@ -17,6 +18,8 @@ export class ScatterPlotComponent implements OnInit {
   @ViewChild(BaseChartDirective)
   private chart: { refresh: () => void } = {refresh: () => console.log('chart not initialized yet')};
 
+  public devices: string = "";
+  public commits: string = "";
   public readonly chartType: ChartType = 'scatter';
   public chartTitle = '';
   public chartData: ChartDataSets[] = Array();
@@ -84,8 +87,10 @@ export class ScatterPlotComponent implements OnInit {
   };
 
 
-  constructor(private readonly route: ActivatedRoute, private readonly dataHandler: ParkviewLibDataService) {
+  constructor(private readonly route: ActivatedRoute, private readonly dataHandler: ParkviewLibDataService, private readonly plotService: PlotService) {
   }
+
+
 
   ngOnInit() {
     this.readParams(this.route.queryParamMap);
@@ -97,6 +102,8 @@ export class ScatterPlotComponent implements OnInit {
       if (config === undefined) {
         return;
       }
+      this.commits = "Commits: " + this.plotService.formatCommits(config.commits);
+      this.devices = "Devices: " + this.plotService.formatDevices(config.devices);
       this.chartTitle = config.labelForTitle;
       this.xLabel = config.labelForXAxis;
       this.yLabel = config.labelForYAxis;

--- a/src/logic/plothandler/plot.service.ts
+++ b/src/logic/plothandler/plot.service.ts
@@ -11,4 +11,31 @@ export class PlotService {
 
   //TODO getGraphData should be implemented correctly later.
   //TODO instead of using the Data interface, we should probably use chart.js' ChartDataSet instead
+
+  formatCommits(commits: string[]) {
+    let res = "";
+    let first = true;
+    for (let commit of commits) {
+      if (!first) {
+        res += ", ";
+      }
+      first = false;
+      res += commit.substr(0, 7);
+    }
+    return res;
+  }
+
+  formatDevices(devices: string[]) {
+    let res = "";
+    let first = true;
+    // Convert to set and back to Array to remove duplicates
+    for (let device of [...new Set(devices)]) {
+      if (!first) {
+        res += ", ";
+      }
+      first = false;
+      res += device;
+    }
+    return res;
+  }
 }


### PR DESCRIPTION
Plot pages now display info on which devices/commit the data was collected on.
See #30.

Example:
<img width="391" alt="image" src="https://user-images.githubusercontent.com/45409137/164944245-260a5637-e79a-46db-83ac-a444dacda2bd.png">
